### PR TITLE
Linux/x64: re-enable assembly routines and prevent illegal relocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,12 +85,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,7 +250,6 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if",
- "cfg_aliases",
  "libc",
  "nasm-rs",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,21 +38,16 @@ nasm-rs = { version = "0.3", features = ["parallel"] }
 
 [features]
 default = [
-    # TODO(#7671): Rerun is getting linker errors on Linux currently.
-    "asm_nonlinux",
+    "asm",
     "asm_arm64_dotprod",
     "asm_arm64_i8mm",
     "bitdepth_8",
     "bitdepth_16",
 ]
-asm_nonlinux = []
-asm_linux = []
-asm_arm64_dotprod = [
-    "asm_nonlinux",
-] # TODO(#7671): Rerun is getting linker errors on Linux currently.
-asm_arm64_i8mm = [
-    "asm_nonlinux",
-] # TODO(#7671): Rerun is getting linker errors on Linux currently.
+# TODO(#7671): Ignored on linux - Rerun is getting linker errors on Linux with this
+asm = []
+asm_arm64_dotprod = ["asm"]
+asm_arm64_i8mm = ["asm"]
 bitdepth_8 = []
 bitdepth_16 = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,14 +37,7 @@ cc = "1.0.79"
 nasm-rs = { version = "0.3", features = ["parallel"] }
 
 [features]
-default = [
-    "asm",
-    "asm_arm64_dotprod",
-    "asm_arm64_i8mm",
-    "bitdepth_8",
-    "bitdepth_16",
-]
-# TODO(#7671): Ignored on linux - Rerun is getting linker errors on Linux with this
+default = ["asm", "asm_arm64_dotprod", "asm_arm64_i8mm", "bitdepth_8", "bitdepth_16"]
 asm = []
 asm_arm64_dotprod = ["asm"]
 asm_arm64_i8mm = ["asm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ zerocopy = { version = "0.7.32", features = ["derive"] }
 
 [build-dependencies]
 cc = "1.0.79"
-cfg_aliases = "0.2.1"
 nasm-rs = { version = "0.3", features = ["parallel"] }
 
 [features]

--- a/build.rs
+++ b/build.rs
@@ -327,8 +327,7 @@ mod asm {
 }
 
 fn main() {
-    // TODO(#7671): Rerun is getting linker errors on Linux right now with enabled asm features.
-    #[cfg(all(feature = "asm", not(target_os = "linux")))]
+    #[cfg(feature = "asm")]
     {
         asm::main();
     }

--- a/build.rs
+++ b/build.rs
@@ -327,15 +327,11 @@ mod asm {
 
 fn main() {
     // TODO(#7671): Rerun is getting linker errors on Linux right now with enabled asm features.
-    cfg_aliases::cfg_aliases! { asm: { any(
-        all(feature = "asm_nonlinux", not(target_os = "linux")),
-        all(feature = "asm_linux", target_os = "linux")
-    ) } };
-
     if cfg!(any(
         all(feature = "asm_nonlinux", not(target_os = "linux")),
         all(feature = "asm_linux", target_os = "linux"),
     )) {
+        println!("cargo:rustc-check-cfg=cfg(\"asm\")");
         asm::main();
     }
 

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::all)]
 
+#[cfg(feature = "asm")]
 mod asm {
     use std::collections::HashSet;
     use std::env;
@@ -327,15 +328,12 @@ mod asm {
 
 fn main() {
     // TODO(#7671): Rerun is getting linker errors on Linux right now with enabled asm features.
-    if cfg!(any(
-        all(feature = "asm_nonlinux", not(target_os = "linux")),
-        all(feature = "asm_linux", target_os = "linux"),
-    )) {
-        println!("cargo:rustc-check-cfg=cfg(\"asm\")");
+    #[cfg(all(feature = "asm", not(target_os = "linux")))]
+    {
         asm::main();
     }
 
-    // NOTE: we rely on libraries that are only distri  buted for Windows so
+    // NOTE: we rely on libraries that are only distributed for Windows so
     // targeting Windows/MSVC is not supported when cross compiling.
     #[cfg(all(target_os = "windows", target_env = "msvc"))]
     {

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -430,7 +430,7 @@ pub type LeftPixelRow2px<Pixel> = [Pixel; 2];
 /// [`avx512icl`]: crate::src::cpu::CpuFlags::AVX512ICL
 /// [`neon`]: crate::src::cpu::CpuFlags::NEON
 #[cfg(all(
-    asm,
+    feature = "asm",
     not(any(target_arch = "riscv64", target_arch = "riscv32"))
 ))]
 macro_rules! bd_fn {
@@ -458,7 +458,7 @@ macro_rules! bd_fn {
 /// Similar to [`bd_fn!`] except that it selects which [`BitDepth`] `fn`
 /// based on `$bpc:literal bpc` instead of `$BD:ty`.
 #[cfg(all(
-    asm,
+    feature = "asm",
     any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")
 ))]
 macro_rules! bpc_fn {
@@ -485,13 +485,13 @@ macro_rules! fn_identity {
 }
 
 #[cfg(all(
-    asm,
+    feature = "asm",
     not(any(target_arch = "riscv64", target_arch = "riscv32"))
 ))]
 pub(crate) use bd_fn;
 
 #[cfg(all(
-    asm,
+    feature = "asm",
     any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")
 ))]
 pub(crate) use bpc_fn;

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -23,10 +23,13 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ptr;
 
-#[cfg(all(asm, not(any(target_arch = "riscv64", target_arch = "riscv32"))))]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 use crate::include::common::bitdepth::bd_fn;
 
-#[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 use crate::include::common::bitdepth::{bpc_fn, BPC};
 
 bitflags! {
@@ -505,7 +508,7 @@ fn cdef_find_dir_rust<BD: BitDepth>(
 }
 
 #[deny(unsafe_op_in_unsafe_fn)]
-#[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 mod neon {
     use super::*;
 
@@ -670,7 +673,7 @@ impl Rav1dCdefDSPContext {
         }
     }
 
-    #[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
     #[inline(always)]
     const fn init_x86<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if matches!(BD::BPC, BPC::BPC8) {
@@ -726,7 +729,7 @@ impl Rav1dCdefDSPContext {
         self
     }
 
-    #[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
     #[inline(always)]
     const fn init_arm<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         use self::neon::cdef_filter_neon_erased;
@@ -745,7 +748,7 @@ impl Rav1dCdefDSPContext {
 
     #[inline(always)]
     const fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
-        #[cfg(asm)]
+        #[cfg(feature = "asm")]
         {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -107,12 +107,12 @@ impl CpuFlags {
         combined_flags
     }
 
-    #[cfg(not(asm))]
+    #[cfg(not(feature = "asm"))]
     pub fn run_time_detect() -> Self {
         Self::empty()
     }
 
-    #[cfg(asm)]
+    #[cfg(feature = "asm")]
     pub fn run_time_detect() -> Self {
         let mut flags = Self::empty();
 

--- a/src/ext/x86/x86inc.asm
+++ b/src/ext/x86/x86inc.asm
@@ -868,6 +868,19 @@ BRANCH_INSTR jz, je, jnz, jne, jl, jle, jnl, jnle, jg, jge, jng, jnge, ja, jae, 
     extern %1
 %endmacro
 
+; %2 and %3 give control over symbol type and symbol visibility, respectively.
+; E.g. `cextern_args some_symbol,data,hidden`.
+;
+; This can be life saving in position-independent contexts, where it is very easy to generate
+; illegal relocations otherwise.
+;
+; See <https://github.com/rerun-io/re_rav1d/pull/3> for more information.
+%macro cextern_args 3
+    %xdefine %1 mangle(private_prefix %+ _ %+ %1)
+    CAT_XDEFINE cglobaled_, %1, 2
+    extern %1:%2 %3
+%endmacro
+
 ; Like cextern, but without the prefix. This should be used for symbols from external libraries.
 %macro cextern_naked 1
     %ifdef PREFIX

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -34,7 +34,7 @@ use std::ptr;
 use to_method::To;
 
 #[cfg(all(
-    asm,
+    feature = "asm",
     not(any(target_arch = "riscv64", target_arch = "riscv32"))
 ))]
 use crate::include::common::bitdepth::bd_fn;
@@ -913,7 +913,7 @@ unsafe extern "C" fn fguv_32x32xn_c_erased<
     )
 }
 
-#[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 mod neon {
     use super::*;
 
@@ -1279,7 +1279,7 @@ impl Rav1dFilmGrainDSPContext {
         }
     }
 
-    #[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
     #[inline(always)]
     const fn init_x86<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::SSSE3) {
@@ -1339,7 +1339,7 @@ impl Rav1dFilmGrainDSPContext {
         self
     }
 
-    #[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
     #[inline(always)]
     const fn init_arm<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::NEON) {
@@ -1365,7 +1365,7 @@ impl Rav1dFilmGrainDSPContext {
 
     #[inline(always)]
     const fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
-        #[cfg(asm)]
+        #[cfg(feature = "asm")]
         {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             {

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -47,12 +47,12 @@ use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 
 #[cfg(all(
-    asm,
+    feature = "asm",
     not(any(target_arch = "riscv64", target_arch = "riscv32"))
 ))]
 use crate::include::common::bitdepth::bd_fn;
 
-#[cfg(all(asm, target_arch = "x86_64"))]
+#[cfg(all(feature = "asm", target_arch = "x86_64"))]
 use crate::include::common::bitdepth::bpc_fn;
 
 wrap_fn_ptr!(pub unsafe extern "C" fn angular_ipred(
@@ -1449,7 +1449,7 @@ unsafe extern "C" fn pal_pred_c_erased<BD: BitDepth>(
     pal_pred_rust::<BD>(dst, pal, idx, w, h)
 }
 
-#[cfg(all(asm, target_arch = "aarch64"))]
+#[cfg(all(feature = "asm", target_arch = "aarch64"))]
 mod neon {
     use super::*;
 
@@ -2056,7 +2056,7 @@ impl Rav1dIntraPredDSPContext {
         }
     }
 
-    #[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
     #[inline(always)]
     const fn init_x86<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::SSSE3) {
@@ -2188,7 +2188,7 @@ impl Rav1dIntraPredDSPContext {
         self
     }
 
-    #[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
     #[inline(always)]
     const fn init_arm<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::NEON) {
@@ -2244,7 +2244,7 @@ impl Rav1dIntraPredDSPContext {
 
     #[inline(always)]
     const fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
-        #[cfg(asm)]
+        #[cfg(feature = "asm")]
         {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             {

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -52,12 +52,12 @@ use std::num::NonZeroUsize;
 use std::slice;
 
 #[cfg(all(
-    asm,
+    feature = "asm",
     not(any(target_arch = "riscv64", target_arch = "riscv32"))
 ))]
 use crate::include::common::bitdepth::bd_fn;
 
-#[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 use crate::include::common::bitdepth::bpc_fn;
 
 pub type Itx1dFn = fn(c: &mut [i32], stride: NonZeroUsize, min: i32, max: i32);
@@ -350,7 +350,7 @@ fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
 }
 
 #[cfg(all(
-    asm,
+    feature = "asm",
     not(any(target_arch = "riscv64", target_arch = "riscv32"))
 ))]
 macro_rules! assign_itx_fn {
@@ -366,7 +366,7 @@ macro_rules! assign_itx_fn {
     }};
 }
 
-#[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 macro_rules! assign_itx_bpc_fn {
     ($c:ident, $w:literal, $h:literal, $type:ident, $type_enum:ident, $bpc:literal bpc, $ext:ident) => {{
         use paste::paste;
@@ -380,21 +380,21 @@ macro_rules! assign_itx_bpc_fn {
     }};
 }
 
-#[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 macro_rules! assign_itx1_bpc_fn {
     ($c:ident, $w:literal, $h:literal, $bpc:literal bpc, $ext:ident) => {{
         assign_itx_bpc_fn!($c, $w, $h, dct_dct, DCT_DCT, $bpc bpc, $ext)
     }};
 }
 
-#[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 macro_rules! assign_itx1_fn {
     ($c:ident, $BD:ty, $w:literal, $h:literal, $ext:ident) => {{
         assign_itx_fn!($c, BD, $w, $h, dct_dct, DCT_DCT, $ext)
     }};
 }
 
-#[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 macro_rules! assign_itx2_bpc_fn {
     ($c:ident, $w:literal, $h:literal, $bpc:literal bpc, $ext:ident) => {{
         assign_itx1_bpc_fn!($c, $w, $h, $bpc bpc, $ext);
@@ -402,7 +402,7 @@ macro_rules! assign_itx2_bpc_fn {
     }};
 }
 
-#[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 macro_rules! assign_itx2_fn {
     ($c:ident, $BD:ty, $w:literal, $h:literal, $ext:ident) => {{
         assign_itx1_fn!($c, BD, $w, $h, $ext);
@@ -410,7 +410,7 @@ macro_rules! assign_itx2_fn {
     }};
 }
 
-#[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 macro_rules! assign_itx12_bpc_fn {
     ($c:ident, $w:literal, $h:literal, $bpc:literal bpc, $ext:ident) => {{
         assign_itx2_bpc_fn!($c, $w, $h, $bpc bpc, $ext);
@@ -427,7 +427,7 @@ macro_rules! assign_itx12_bpc_fn {
     }};
 }
 
-#[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 macro_rules! assign_itx12_fn {
     ($c:ident, $BD:ty, $w:literal, $h:literal, $ext:ident) => {{
         assign_itx2_fn!($c, BD, $w, $h, $ext);
@@ -444,7 +444,7 @@ macro_rules! assign_itx12_fn {
     }};
 }
 
-#[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 macro_rules! assign_itx16_bpc_fn {
     ($c:ident, $w:literal, $h:literal, $bpc:literal bpc, $ext:ident) => {{
         assign_itx12_bpc_fn!($c, $w, $h, $bpc bpc, $ext);
@@ -455,7 +455,7 @@ macro_rules! assign_itx16_bpc_fn {
     }};
 }
 
-#[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 macro_rules! assign_itx16_fn {
     ($c:ident, $BD:ty, $w:literal, $h:literal, $ext:ident) => {{
         assign_itx12_fn!($c, BD, $w, $h, $ext);
@@ -544,7 +544,7 @@ impl Rav1dInvTxfmDSPContext {
         c
     }
 
-    #[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
     #[inline(always)]
     const fn init_x86<BD: BitDepth>(mut self, flags: CpuFlags, bpc: u8) -> Self {
         if !flags.contains(CpuFlags::SSE2) {
@@ -721,7 +721,7 @@ impl Rav1dInvTxfmDSPContext {
         self
     }
 
-    #[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
     #[inline(always)]
     const fn init_arm<BD: BitDepth>(mut self, flags: CpuFlags, bpc: u8) -> Self {
         if !flags.contains(CpuFlags::NEON) {
@@ -764,7 +764,7 @@ impl Rav1dInvTxfmDSPContext {
 
     #[inline(always)]
     const fn init<BD: BitDepth>(self, flags: CpuFlags, bpc: u8) -> Self {
-        #[cfg(asm)]
+        #[cfg(feature = "asm")]
         {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             {

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -20,7 +20,7 @@ use std::ffi::c_int;
 use strum::FromRepr;
 
 #[cfg(all(
-    asm,
+    feature = "asm",
     not(any(target_arch = "riscv64", target_arch = "riscv32"))
 ))]
 use crate::include::common::bitdepth::bd_fn;
@@ -397,7 +397,7 @@ impl Rav1dLoopFilterDSPContext {
         }
     }
 
-    #[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
     #[inline(always)]
     const fn init_x86<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::SSSE3) {
@@ -437,7 +437,7 @@ impl Rav1dLoopFilterDSPContext {
         self
     }
 
-    #[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
     #[inline(always)]
     const fn init_arm<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::NEON) {
@@ -454,7 +454,7 @@ impl Rav1dLoopFilterDSPContext {
 
     #[inline(always)]
     const fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
-        #[cfg(asm)]
+        #[cfg(feature = "asm")]
         {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             {

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -31,12 +31,12 @@ use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
 
 #[cfg(all(
-    asm,
+    feature = "asm",
     any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")
 ))]
 use crate::include::common::bitdepth::bd_fn;
 
-#[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 use crate::include::common::bitdepth::bpc_fn;
 
 bitflags! {
@@ -957,7 +957,7 @@ fn sgr_mix_rust<BD: BitDepth>(
 }
 
 #[deny(unsafe_op_in_unsafe_fn)]
-#[cfg(all(asm, target_arch = "arm"))]
+#[cfg(all(feature = "asm", target_arch = "arm"))]
 mod neon {
     use super::*;
 
@@ -1572,7 +1572,7 @@ mod neon {
 }
 
 #[deny(unsafe_op_in_unsafe_fn)]
-#[cfg(all(asm, target_arch = "aarch64"))]
+#[cfg(all(feature = "asm", target_arch = "aarch64"))]
 mod neon {
     use super::*;
 
@@ -3318,7 +3318,7 @@ mod neon {
 }
 
 #[deny(unsafe_op_in_unsafe_fn)]
-#[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 mod neon_erased {
     use super::*;
 
@@ -3422,7 +3422,7 @@ impl Rav1dLoopRestorationDSPContext {
         }
     }
 
-    #[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
     #[inline(always)]
     const fn init_x86<BD: BitDepth>(mut self, flags: CpuFlags, bpc: u8) -> Self {
         if !flags.contains(CpuFlags::SSE2) {
@@ -3505,7 +3505,7 @@ impl Rav1dLoopRestorationDSPContext {
         self
     }
 
-    #[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
     #[inline(always)]
     const fn init_arm<BD: BitDepth>(mut self, flags: CpuFlags, bpc: u8) -> Self {
         if !flags.contains(CpuFlags::NEON) {
@@ -3539,7 +3539,7 @@ impl Rav1dLoopRestorationDSPContext {
 
     #[inline(always)]
     const fn init<BD: BitDepth>(self, flags: CpuFlags, bpc: u8) -> Self {
-        #[cfg(asm)]
+        #[cfg(feature = "asm")]
         {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             {

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -38,15 +38,15 @@ use std::slice;
 use to_method::To;
 
 #[cfg(all(
-    asm,
+    feature = "asm",
     not(any(target_arch = "riscv64", target_arch = "riscv32"))
 ))]
 use crate::include::common::bitdepth::bd_fn;
 
-#[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 use crate::include::common::bitdepth::{bpc_fn, BPC};
 
-#[cfg(all(asm, target_arch = "aarch64"))]
+#[cfg(all(feature = "asm", target_arch = "aarch64"))]
 use crate::include::common::bitdepth::bpc_fn;
 
 #[inline(never)]
@@ -2025,7 +2025,7 @@ impl Rav1dMCDSPContext {
         }
     }
 
-    #[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
     #[inline(always)]
     const fn init_x86<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::SSE2) {
@@ -2256,7 +2256,7 @@ impl Rav1dMCDSPContext {
         self
     }
 
-    #[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
     #[inline(always)]
     const fn init_arm<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::NEON) {
@@ -2374,7 +2374,7 @@ impl Rav1dMCDSPContext {
 
     #[inline(always)]
     const fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
-        #[cfg(asm)]
+        #[cfg(feature = "asm")]
         {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             {

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -15,7 +15,7 @@ use std::ops::Range;
 use std::ptr;
 use std::slice;
 
-#[cfg(all(asm, target_feature = "sse2"))]
+#[cfg(all(feature = "asm", target_feature = "sse2"))]
 extern "C" {
     fn dav1d_msac_decode_hi_tok_sse2(s: *mut MsacAsmContext, cdf: *mut u16) -> c_uint;
     fn dav1d_msac_decode_bool_sse2(s: *mut MsacAsmContext, f: c_uint) -> c_uint;
@@ -39,7 +39,7 @@ extern "C" {
     ) -> c_uint;
 }
 
-#[cfg(all(asm, target_arch = "x86_64"))]
+#[cfg(all(feature = "asm", target_arch = "x86_64"))]
 extern "C" {
     fn dav1d_msac_decode_symbol_adapt16_avx2(
         s: &mut MsacAsmContext,
@@ -49,7 +49,7 @@ extern "C" {
     ) -> c_uint;
 }
 
-#[cfg(all(asm, target_feature = "neon"))]
+#[cfg(all(feature = "asm", target_feature = "neon"))]
 extern "C" {
     fn dav1d_msac_decode_hi_tok_neon(s: *mut MsacAsmContext, cdf: *mut u16) -> c_uint;
     fn dav1d_msac_decode_bool_neon(s: *mut MsacAsmContext, f: c_uint) -> c_uint;
@@ -88,7 +88,7 @@ impl Rav1dMsacDSPContext {
         }
     }
 
-    #[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
     #[inline(always)]
     const fn init_x86(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::SSE2) {
@@ -109,7 +109,7 @@ impl Rav1dMsacDSPContext {
         self
     }
 
-    #[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
     #[inline(always)]
     const fn init_arm(self, _flags: CpuFlags) -> Self {
         self
@@ -117,7 +117,7 @@ impl Rav1dMsacDSPContext {
 
     #[inline(always)]
     const fn init(self, flags: CpuFlags) -> Self {
-        #[cfg(asm)]
+        #[cfg(feature = "asm")]
         {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             {
@@ -199,7 +199,7 @@ pub struct MsacAsmContext {
     pub rng: c_uint,
     pub cnt: c_int,
     allow_update_cdf: c_int,
-    #[cfg(all(asm, target_arch = "x86_64"))]
+    #[cfg(all(feature = "asm", target_arch = "x86_64"))]
     symbol_adapt16: unsafe extern "C" fn(
         s: &mut MsacAsmContext,
         cdf: *mut u16,
@@ -217,7 +217,7 @@ impl Default for MsacAsmContext {
             cnt: Default::default(),
             allow_update_cdf: Default::default(),
 
-            #[cfg(all(asm, target_arch = "x86_64"))]
+            #[cfg(all(feature = "asm", target_arch = "x86_64"))]
             symbol_adapt16: Rav1dMsacDSPContext::default().symbol_adapt16,
         }
     }
@@ -339,7 +339,7 @@ fn ctx_norm(s: &mut MsacContext, dif: EcWin, rng: c_uint) {
 }
 
 #[cfg_attr(
-    all(asm, any(target_feature = "sse2", target_feature = "neon")),
+    all(feature = "asm", any(target_feature = "sse2", target_feature = "neon")),
     allow(dead_code)
 )]
 fn rav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> bool {
@@ -356,7 +356,7 @@ fn rav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> bool {
 }
 
 #[cfg_attr(
-    all(asm, any(target_feature = "sse2", target_feature = "neon")),
+    all(feature = "asm", any(target_feature = "sse2", target_feature = "neon")),
     allow(dead_code)
 )]
 fn rav1d_msac_decode_bool_rust(s: &mut MsacContext, f: c_uint) -> bool {
@@ -436,7 +436,7 @@ fn rav1d_msac_decode_symbol_adapt_rust(s: &mut MsacContext, cdf: &mut [u16], n_s
 ///
 /// Must be called through [`Rav1dMsacDSPContext::symbol_adapt16`]
 /// in [`rav1d_msac_decode_symbol_adapt16`].
-#[cfg_attr(not(all(asm, target_arch = "x86_64")), allow(dead_code))]
+#[cfg_attr(not(all(feature = "asm", target_arch = "x86_64")), allow(dead_code))]
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn rav1d_msac_decode_symbol_adapt_c(
     s: &mut MsacAsmContext,
@@ -462,7 +462,7 @@ unsafe extern "C" fn rav1d_msac_decode_symbol_adapt_c(
 }
 
 #[cfg_attr(
-    all(asm, any(target_feature = "sse2", target_feature = "neon")),
+    all(feature = "asm", any(target_feature = "sse2", target_feature = "neon")),
     allow(dead_code)
 )]
 fn rav1d_msac_decode_bool_adapt_rust(s: &mut MsacContext, cdf: &mut [u16; 2]) -> bool {
@@ -482,7 +482,7 @@ fn rav1d_msac_decode_bool_adapt_rust(s: &mut MsacContext, cdf: &mut [u16; 2]) ->
 
 /// Return value is in the range `0..=15`.
 #[cfg_attr(
-    all(asm, any(target_feature = "sse2", target_feature = "neon")),
+    all(feature = "asm", any(target_feature = "sse2", target_feature = "neon")),
     allow(dead_code)
 )]
 fn rav1d_msac_decode_hi_tok_rust(s: &mut MsacContext, cdf: &mut [u16; 4]) -> u8 {
@@ -510,7 +510,7 @@ impl MsacContext {
             rng: 0x8000,
             cnt: -15,
             allow_update_cdf: (!disable_cdf_update_flag).into(),
-            #[cfg(all(asm, target_arch = "x86_64"))]
+            #[cfg(all(feature = "asm", target_arch = "x86_64"))]
             symbol_adapt16: dsp.symbol_adapt16,
         };
         let mut s = Self {
@@ -531,12 +531,12 @@ pub fn rav1d_msac_decode_symbol_adapt4(s: &mut MsacContext, cdf: &mut [u16], n_s
     debug_assert!(n_symbols < 4);
     let ret;
     cfg_if! {
-        if #[cfg(all(asm, target_feature = "sse2"))] {
+        if #[cfg(all(feature = "asm", target_feature = "sse2"))] {
             // SAFETY: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].
             ret = unsafe {
                 dav1d_msac_decode_symbol_adapt4_sse2(&mut s.asm, cdf.as_mut_ptr(), n_symbols as usize)
             };
-        } else if #[cfg(all(asm, target_feature = "neon"))] {
+        } else if #[cfg(all(feature = "asm", target_feature = "neon"))] {
             // SAFETY: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].
             ret = unsafe {
                 dav1d_msac_decode_symbol_adapt4_neon(&mut s.asm, cdf.as_mut_ptr(), n_symbols as usize)
@@ -557,12 +557,12 @@ pub fn rav1d_msac_decode_symbol_adapt8(s: &mut MsacContext, cdf: &mut [u16], n_s
     debug_assert!(n_symbols < 8);
     let ret;
     cfg_if! {
-        if #[cfg(all(asm, target_feature = "sse2"))] {
+        if #[cfg(all(feature = "asm", target_feature = "sse2"))] {
             // SAFETY: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].
             ret = unsafe {
                 dav1d_msac_decode_symbol_adapt8_sse2(&mut s.asm, cdf.as_mut_ptr(), n_symbols as usize)
             };
-        } else if #[cfg(all(asm, target_feature = "neon"))] {
+        } else if #[cfg(all(feature = "asm", target_feature = "neon"))] {
             // SAFETY: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].
             ret = unsafe {
                 dav1d_msac_decode_symbol_adapt8_neon(&mut s.asm, cdf.as_mut_ptr(), n_symbols as usize)
@@ -583,17 +583,17 @@ pub fn rav1d_msac_decode_symbol_adapt16(s: &mut MsacContext, cdf: &mut [u16], n_
     debug_assert!(n_symbols < 16);
     let ret;
     cfg_if! {
-        if #[cfg(all(asm, target_arch = "x86_64"))] {
+        if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
             // SAFETY: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].
             ret = unsafe {
                 (s.symbol_adapt16)(&mut s.asm, cdf.as_mut_ptr(), n_symbols as usize, cdf.len())
             };
-        } else if #[cfg(all(asm, target_feature = "sse2"))] {
+        } else if #[cfg(all(feature = "asm", target_feature = "sse2"))] {
             // SAFETY: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].
             ret = unsafe {
                 dav1d_msac_decode_symbol_adapt16_sse2(&mut s.asm, cdf.as_mut_ptr(), n_symbols as usize, cdf.len())
             };
-        } else if #[cfg(all(asm, target_feature = "neon"))] {
+        } else if #[cfg(all(feature = "asm", target_feature = "neon"))] {
             // SAFETY: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].
             ret = unsafe {
                 dav1d_msac_decode_symbol_adapt16_neon(&mut s.asm, cdf.as_mut_ptr(), n_symbols as usize)
@@ -608,12 +608,12 @@ pub fn rav1d_msac_decode_symbol_adapt16(s: &mut MsacContext, cdf: &mut [u16], n_
 
 pub fn rav1d_msac_decode_bool_adapt(s: &mut MsacContext, cdf: &mut [u16; 2]) -> bool {
     cfg_if! {
-        if #[cfg(all(asm, target_feature = "sse2"))] {
+        if #[cfg(all(feature = "asm", target_feature = "sse2"))] {
             // SAFETY: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_bool_adapt_rust`].
             unsafe {
                 dav1d_msac_decode_bool_adapt_sse2(&mut s.asm, cdf.as_mut_ptr()) != 0
             }
-        } else if #[cfg(all(asm, target_feature = "neon"))] {
+        } else if #[cfg(all(feature = "asm", target_feature = "neon"))] {
             // SAFETY: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_bool_adapt_rust`].
             unsafe {
                 dav1d_msac_decode_bool_adapt_neon(&mut s.asm, cdf.as_mut_ptr()) != 0
@@ -626,12 +626,12 @@ pub fn rav1d_msac_decode_bool_adapt(s: &mut MsacContext, cdf: &mut [u16; 2]) -> 
 
 pub fn rav1d_msac_decode_bool_equi(s: &mut MsacContext) -> bool {
     cfg_if! {
-        if #[cfg(all(asm, target_feature = "sse2"))] {
+        if #[cfg(all(feature = "asm", target_feature = "sse2"))] {
             // SAFETY: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_bool_equi_rust`].
             unsafe {
                 dav1d_msac_decode_bool_equi_sse2(&mut s.asm) != 0
             }
-        } else if #[cfg(all(asm, target_feature = "neon"))] {
+        } else if #[cfg(all(feature = "asm", target_feature = "neon"))] {
             // SAFETY: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_bool_equi_rust`].
             unsafe {
                 dav1d_msac_decode_bool_equi_neon(&mut s.asm) != 0
@@ -644,12 +644,12 @@ pub fn rav1d_msac_decode_bool_equi(s: &mut MsacContext) -> bool {
 
 pub fn rav1d_msac_decode_bool(s: &mut MsacContext, f: c_uint) -> bool {
     cfg_if! {
-        if #[cfg(all(asm, target_feature = "sse2"))] {
+        if #[cfg(all(feature = "asm", target_feature = "sse2"))] {
             // SAFETY: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_bool_rust`].
             unsafe {
                 dav1d_msac_decode_bool_sse2(&mut s.asm, f) != 0
             }
-        } else if #[cfg(all(asm, target_feature = "neon"))] {
+        } else if #[cfg(all(feature = "asm", target_feature = "neon"))] {
             // SAFETY: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_bool_rust`].
             unsafe {
                 dav1d_msac_decode_bool_neon(&mut s.asm, f) != 0
@@ -665,12 +665,12 @@ pub fn rav1d_msac_decode_bool(s: &mut MsacContext, f: c_uint) -> bool {
 pub fn rav1d_msac_decode_hi_tok(s: &mut MsacContext, cdf: &mut [u16; 4]) -> u8 {
     let ret;
     cfg_if! {
-        if #[cfg(all(asm, target_feature = "sse2"))] {
+        if #[cfg(all(feature = "asm", target_feature = "sse2"))] {
             // SAFETY: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_hi_tok_rust`].
             ret = (unsafe {
                 dav1d_msac_decode_hi_tok_sse2(&mut s.asm, cdf.as_mut_ptr())
             }) as u8;
-        } else if #[cfg(all(asm, target_feature = "neon"))] {
+        } else if #[cfg(all(feature = "asm", target_feature = "neon"))] {
             // SAFETY: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_hi_tok_rust`].
             ret = unsafe {
                 dav1d_msac_decode_hi_tok_neon(&mut s.asm, cdf.as_mut_ptr())

--- a/src/pal.rs
+++ b/src/pal.rs
@@ -138,7 +138,7 @@ impl Rav1dPalDSPContext {
         }
     }
 
-    #[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
     #[inline(always)]
     const fn init_x86(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::SSSE3) {
@@ -165,7 +165,7 @@ impl Rav1dPalDSPContext {
         self
     }
 
-    #[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
     #[inline(always)]
     const fn init_arm(self, _flags: CpuFlags) -> Self {
         self
@@ -173,7 +173,7 @@ impl Rav1dPalDSPContext {
 
     #[inline(always)]
     const fn init(self, flags: CpuFlags) -> Self {
-        #[cfg(asm)]
+        #[cfg(feature = "asm")]
         {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             {

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1736,7 +1736,7 @@ impl Rav1dRefmvsDSPContext {
         }
     }
 
-    #[cfg(all(asm, any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
     #[inline(always)]
     const fn init_x86(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::SSE2) {
@@ -1777,7 +1777,7 @@ impl Rav1dRefmvsDSPContext {
         self
     }
 
-    #[cfg(all(asm, any(target_arch = "arm", target_arch = "aarch64")))]
+    #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
     #[inline(always)]
     const fn init_arm(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::NEON) {
@@ -1792,7 +1792,7 @@ impl Rav1dRefmvsDSPContext {
 
     #[inline(always)]
     const fn init(self, flags: CpuFlags) -> Self {
-        #[cfg(asm)]
+        #[cfg(feature = "asm")]
         {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             {

--- a/src/wrap_fn_ptr.rs
+++ b/src/wrap_fn_ptr.rs
@@ -79,7 +79,7 @@ macro_rules! wrap_fn_ptr {
                 };
             }
 
-            #[cfg(asm)]
+            #[cfg(feature = "asm")]
             #[allow(unused_macros)]
             macro_rules! decl_fn {
                 (fn $fn_name:ident) => {{
@@ -91,7 +91,7 @@ macro_rules! wrap_fn_ptr {
                 }};
             }
 
-            #[cfg(asm)]
+            #[cfg(feature = "asm")]
             #[allow(unused_imports)]
             pub(crate) use decl_fn;
         }

--- a/src/x86/filmgrain_common.asm
+++ b/src/x86/filmgrain_common.asm
@@ -43,4 +43,4 @@ struc FGData
     .clip_to_restricted_range:  resd 1
 endstruc
 
-cextern gaussian_sequence
+cextern_args gaussian_sequence,data,hidden

--- a/src/x86/ipred16_avx2.asm
+++ b/src/x86/ipred16_avx2.asm
@@ -129,8 +129,8 @@ JMP_TABLE ipred_cfl_left_16bpc,   avx2, h4, h8, h16, h32
 JMP_TABLE ipred_cfl_ac_444_16bpc, avx2, w4, w8, w16, w32
 JMP_TABLE pal_pred_16bpc,         avx2, w4, w8, w16, w32, w64
 
-cextern dr_intra_derivative
-cextern filter_intra_taps
+cextern_args dr_intra_derivative,data,hidden
+cextern_args filter_intra_taps,data,hidden
 
 SECTION .text
 

--- a/src/x86/ipred16_avx512.asm
+++ b/src/x86/ipred16_avx512.asm
@@ -121,10 +121,10 @@ JMP_TABLE ipred_z2_16bpc,         avx512icl, w4, w8, w16, w32, w64
 JMP_TABLE ipred_z3_16bpc,         avx512icl, w4, w8, w16, w32, w64
 JMP_TABLE pal_pred_16bpc,         avx512icl, w4, w8, w16, w32, w64
 
-cextern smooth_weights_1d_16bpc
-cextern smooth_weights_2d_16bpc
-cextern dr_intra_derivative
-cextern filter_intra_taps
+cextern_args smooth_weights_1d_16bpc,data,hidden
+cextern_args smooth_weights_2d_16bpc,data,hidden
+cextern_args dr_intra_derivative,data,hidden
+cextern_args filter_intra_taps,data,hidden
 
 SECTION .text
 

--- a/src/x86/ipred16_sse.asm
+++ b/src/x86/ipred16_sse.asm
@@ -99,10 +99,10 @@ JMP_TABLE ipred_cfl_left_16bpc,   ssse3, h4, h8, h16, h32
 JMP_TABLE ipred_cfl_ac_444_16bpc, ssse3, w4, w8, w16, w32
 JMP_TABLE pal_pred_16bpc,         ssse3, w4, w8, w16, w32, w64
 
-cextern smooth_weights_1d_16bpc
-cextern smooth_weights_2d_16bpc
-cextern dr_intra_derivative
-cextern filter_intra_taps
+cextern_args smooth_weights_1d_16bpc,data,hidden
+cextern_args smooth_weights_2d_16bpc,data,hidden
+cextern_args dr_intra_derivative,data,hidden
+cextern_args filter_intra_taps,data,hidden
 
 SECTION .text
 

--- a/src/x86/ipred_avx2.asm
+++ b/src/x86/ipred_avx2.asm
@@ -173,8 +173,8 @@ JMP_TABLE ipred_cfl_ac_422, avx2, w16_pad1, w16_pad2, w16_pad3
 JMP_TABLE ipred_cfl_ac_444, avx2, w32_pad1, w32_pad2, w32_pad3, w4, w8, w16, w32
 JMP_TABLE pal_pred,         avx2, w4, w8, w16, w32, w64
 
-cextern dr_intra_derivative
-cextern filter_intra_taps
+cextern_args dr_intra_derivative,data,hidden
+cextern_args filter_intra_taps,data,hidden
 
 SECTION .text
 

--- a/src/x86/ipred_avx512.asm
+++ b/src/x86/ipred_avx512.asm
@@ -213,8 +213,8 @@ JMP_TABLE ipred_dc_8bpc,         avx512icl, h4, h8, h16, h32, h64, w4, w8, w16, 
                                        s4-10*4, s8-10*4, s16-10*4, s32-10*4, s64-10*4
 JMP_TABLE ipred_dc_left_8bpc,    avx512icl, h4, h8, h16, h32, h64
 
-cextern dr_intra_derivative
-cextern pb_0to63
+cextern_args dr_intra_derivative,data,hidden
+cextern_args pb_0to63,data,hidden
 
 SECTION .text
 

--- a/src/x86/ipred_sse.asm
+++ b/src/x86/ipred_sse.asm
@@ -141,8 +141,8 @@ JMP_TABLE ipred_cfl,        ssse3, h4, h8, h16, h32, w4, w8, w16, w32, \
 JMP_TABLE ipred_cfl_left,   ssse3, h4, h8, h16, h32
 JMP_TABLE ipred_filter,     ssse3, w4, w8, w16, w32
 
-cextern dr_intra_derivative
-cextern filter_intra_taps
+cextern_args dr_intra_derivative,data,hidden
+cextern_args filter_intra_taps,data,hidden
 
 SECTION .text
 

--- a/src/x86/looprestoration16_avx2.asm
+++ b/src/x86/looprestoration16_avx2.asm
@@ -62,8 +62,8 @@ pd_0xf00801c7: dd 0xf00801c7
 
 %define pw_256 sgr_lshuf5
 
-cextern pb_0to63
-cextern sgr_x_by_x_avx2
+cextern_args pb_0to63,data,hidden
+cextern_args sgr_x_by_x_avx2,data,hidden
 
 SECTION .text
 

--- a/src/x86/looprestoration16_avx512.asm
+++ b/src/x86/looprestoration16_avx512.asm
@@ -51,7 +51,7 @@ pd_m9:         dd -9
 pd_8:          dd 8
 pd_2147483648: dd 2147483648
 
-cextern sgr_x_by_x
+cextern_args sgr_x_by_x,data,hidden
 
 SECTION .text
 

--- a/src/x86/looprestoration16_sse.asm
+++ b/src/x86/looprestoration16_sse.asm
@@ -59,7 +59,7 @@ pd_0xfffffff0: times 4 dd 0xfffffff0
 wiener_shifts: dw 4, 4, 2048, 2048, 1, 1, 8192, 8192
 wiener_round:  dd 1049600, 1048832
 
-cextern sgr_x_by_x
+cextern_args sgr_x_by_x,data,hidden
 
 SECTION .text
 

--- a/src/x86/looprestoration_avx512.asm
+++ b/src/x86/looprestoration_avx512.asm
@@ -53,7 +53,7 @@ pd_m9:         dd -9
 pd_34816:      dd 34816
 pd_8421376:    dd 8421376
 
-cextern sgr_x_by_x
+cextern_args sgr_x_by_x,data,hidden
 
 SECTION .text
 

--- a/src/x86/looprestoration_sse.asm
+++ b/src/x86/looprestoration_sse.asm
@@ -51,7 +51,7 @@ pd_0xffff:     times 4 dd 0xffff
 pd_0xf00800a4: times 4 dd 0xf00800a4
 pd_0xf00801c7: times 4 dd 0xf00801c7
 
-cextern sgr_x_by_x
+cextern_args sgr_x_by_x,data,hidden
 
 SECTION .text
 

--- a/src/x86/mc16_avx2.asm
+++ b/src/x86/mc16_avx2.asm
@@ -194,11 +194,11 @@ SCALED_JMP_TABLE prep_8tap_scaled, avx2,   4, 8, 16, 32, 64, 128
 
 %define table_offset(type, fn) type %+ fn %+ SUFFIX %+ _table - type %+ SUFFIX
 
-cextern mc_subpel_filters
+cextern_args mc_subpel_filters,data,hidden
 %define subpel_filters (mangle(private_prefix %+ _mc_subpel_filters)-8)
 
-cextern mc_warp_filter
-cextern resize_filter
+cextern_args mc_warp_filter,data,hidden
+cextern_args resize_filter,data,hidden
 
 SECTION .text
 

--- a/src/x86/mc16_avx512.asm
+++ b/src/x86/mc16_avx512.asm
@@ -251,12 +251,12 @@ HV_JMP_TABLE   prep, 8tap,  avx512icl, 2,    4, 8, 16, 32, 64, 128
 
 %define table_offset(type, fn) type %+ fn %+ SUFFIX %+ _table - type %+ SUFFIX
 
-cextern mc_subpel_filters
+cextern_args mc_subpel_filters,data,hidden
 %define subpel_filters (mangle(private_prefix %+ _mc_subpel_filters)-8)
 
-cextern mc_warp_filter
-cextern obmc_masks_avx2
-cextern resize_filter
+cextern_args mc_warp_filter,data,hidden
+cextern_args obmc_masks_avx2,data,hidden
+cextern_args resize_filter,data,hidden
 
 SECTION .text
 

--- a/src/x86/mc16_sse.asm
+++ b/src/x86/mc16_sse.asm
@@ -158,11 +158,11 @@ BASE_JMP_TABLE prep, ssse3,    4, 8, 16, 32, 64, 128
 SCALED_JMP_TABLE put_8tap_scaled, ssse3, 2, 4, 8, 16, 32, 64, 128
 SCALED_JMP_TABLE prep_8tap_scaled, ssse3,   4, 8, 16, 32, 64, 128
 
-cextern mc_subpel_filters
+cextern_args mc_subpel_filters,data,hidden
 %define subpel_filters (mangle(private_prefix %+ _mc_subpel_filters)-8)
 
-cextern mc_warp_filter
-cextern resize_filter
+cextern_args mc_warp_filter,data,hidden
+cextern_args resize_filter,data,hidden
 
 SECTION .text
 

--- a/src/x86/mc_avx2.asm
+++ b/src/x86/mc_avx2.asm
@@ -91,10 +91,10 @@ pd_0x3ff:        dd 0x3ff
 pd_0x4000:       dd 0x4000
 pq_0x40000000:   dq 0x40000000
 
-cextern mc_subpel_filters
-cextern mc_warp_filter2
-cextern resize_filter
-cextern z_filter_s
+cextern_args mc_subpel_filters,data,hidden
+cextern_args mc_warp_filter2,data,hidden
+cextern_args resize_filter,data,hidden
+cextern_args z_filter_s,data,hidden
 
 %define subpel_filters (mangle(private_prefix %+ _mc_subpel_filters)-8)
 

--- a/src/x86/mc_avx512.asm
+++ b/src/x86/mc_avx512.asm
@@ -200,10 +200,10 @@ pd_512:             dd 512
 %define pb_64  (wm_sign+8)
 %define pd_2   (pd_0to7+8)
 
-cextern mc_subpel_filters
+cextern_args mc_subpel_filters,data,hidden
 %define subpel_filters (mangle(private_prefix %+ _mc_subpel_filters)-8)
-cextern mc_warp_filter
-cextern resize_filter
+cextern_args mc_warp_filter,data,hidden
+cextern_args resize_filter,data,hidden
 
 %macro BASE_JMP_TABLE 3-*
     %xdefine %1_%2_table (%%table - %3)

--- a/src/x86/mc_sse.asm
+++ b/src/x86/mc_sse.asm
@@ -202,7 +202,7 @@ const mc_warp_filter2 ; dav1d_mc_warp_filter[] reordered for pmaddubsw usage
 
 pw_258:  times 2 dw 258
 
-cextern mc_subpel_filters
+cextern_args mc_subpel_filters,data,hidden
 %define subpel_filters (mangle(private_prefix %+ _mc_subpel_filters)-8)
 
 %macro BIDIR_JMP_TABLE 2-*
@@ -9357,7 +9357,7 @@ cglobal emu_edge_8bpc, 10, 13, 2, bw, bh, iw, ih, x, \
 %undef reg_blkm
 %undef reg_tmp
 
-cextern resize_filter
+cextern_args resize_filter,data,hidden
 
 %macro SCRATCH 3
 %if ARCH_X86_32

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -23,15 +23,8 @@ libc = "0.2"
 rav1d = { path = "../", version = "0.1.0", package = "re_rav1d", default-features = false }
 
 [features]
-default = [
-    "asm_nonlinux",
-    "asm_arm64_dotprod",
-    "asm_arm64_i8mm",
-    "bitdepth_8",
-    "bitdepth_16",
-]
-asm_nonlinux = ["rav1d/asm_nonlinux"]
-asm_linux = ["rav1d/asm_linux"]
+default = ["asm", "asm_arm64_dotprod", "asm_arm64_i8mm", "bitdepth_8", "bitdepth_16"]
+asm = ["rav1d/asm"]
 asm_arm64_dotprod = ["rav1d/asm_arm64_dotprod"]
 asm_arm64_i8mm = ["rav1d/asm_arm64_i8mm"]
 bitdepth_8 = ["rav1d/bitdepth_8"]


### PR DESCRIPTION
Here's some notes for the next poor soul that has to deal with this. I'm omitting a lot for the sake of brievety/sanity (no, really), but it should be enough to get started and running in the right direction...

It's safe to assume that I got some (if not all) things wrong. Clarifications welcome.

## Context

### The problem

On linux/x64, assuming you're using any of the problematic symbols, `rav1d` will fail to link with the following errors:
```
mold: error: /home/cmc/dev/rerun-io/rerun/target/debug/deps/libre_rav1d-d1774017185e2712.rlib(mc_avx2.o):(.text): R_X86_64_PC32 relocation at offset 0x7562 against symbol `dav1d_mc_subpel_filters' can not be used; recompile with -fPIC
mold: error: /home/cmc/dev/rerun-io/rerun/target/debug/deps/libre_rav1d-d1774017185e2712.rlib(mc16_avx2.o):(.text): R_X86_64_PC32 relocation at offset 0xa65c against symbol `dav1d_resize_filter' can not be used; recompile with -fPIC
mold: error: /home/cmc/dev/rerun-io/rerun/target/debug/deps/libre_rav1d-d1774017185e2712.rlib(mc16_avx2.o):(.text): R_X86_64_PC32 relocation at offset 0xa687 against symbol `dav1d_resize_filter' can not be used; recompile with -fPIC
mold: error: /home/cmc/dev/rerun-io/rerun/target/debug/deps/libre_rav1d-d1774017185e2712.rlib(mc_avx2.o):(.text): R_X86_64_PC32 relocation at offset 0x7581 against symbol `dav1d_mc_subpel_filters' can not be used; recompile with -fPIC
mold: error: /home/cmc/dev/rerun-io/rerun/target/debug/deps/libre_rav1d-d1774017185e2712.rlib(mc16_avx2.o):(.text): R_X86_64_PC32 relocation at offset 0xa691 against symbol `dav1d_resize_filter' can not be used; recompile with -fPIC
# ... more of the same ...
```

This error message is infamously bogus: it's not only misleading, it's leading you in the exact opposite direction of where you wanna go.
No, the issue is not that you forgot to compile position-independent code, the issue is that you are in fact very much compiling position-independent code, and that's a problem. Let's look at why that is.


### SIMD-rav1d in a nutshell

rav1d's SIMD routines work by sampling tables of data at runtime. These tables are defined, and exposed, in `tables.rs`. Here's one of them:
https://github.com/rerun-io/re_rav1d/blob/8097727f9ce722d02fd8a95fb6938dfeb740c490/src/tables.rs#L1004-L1070

These tables are then referenced in the SIMD routines directly, using their non-mangled symbol.
This is achieved via the `cextern` macro:
https://github.com/rerun-io/re_rav1d/blob/8097727f9ce722d02fd8a95fb6938dfeb740c490/src/ext/x86/x86inc.asm#L865-L869

The `cextern` macro does a bunch of things (btw, `private_prefix` == `dav1d`) that we don't really need to concern ourselves with, but most importantly it bottoms out to [`extern`](https://www.tortall.net/projects/yasm/manual/html/nasm-directive-extern.html), which does what you think it does (and in fact so, so much more...).

Example usage:
https://github.com/rerun-io/re_rav1d/blob/54888c3376e4f7fe34c772b67c5ec2436f447d64/src/x86/mc_sse.asm#L9360
https://github.com/rerun-io/re_rav1d/blob/54888c3376e4f7fe34c772b67c5ec2436f447d64/src/x86/mc_sse.asm#L9536-L9539

The [build script](https://github.com/rerun-io/re_rav1d/blob/54888c3376e4f7fe34c772b67c5ec2436f447d64/build.rs#L289-L325) compiles those tables into object files, assembles these SIMD routines into yet other object files, and finally pack all of that in a neat little Rust archive (`.rlib` is really just a `.a` with some extra Rust metadata baked in).

If you check out the symbols, you'll find what you'd expect. Here's e.g. `dav1d_resize_filter`:
```
$ readelf --wide -s target/release/libre_rav1d.rlib | rg resize_filter
  5141: 0000000000000000   512 OBJECT  GLOBAL DEFAULT 4682 dav1d_resize_filter
   676: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND dav1d_resize_filter
   572: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND dav1d_resize_filter
   474: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND dav1d_resize_filter
   459: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND dav1d_resize_filter
   544: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND dav1d_resize_filter
   482: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND dav1d_resize_filter
```
The actual table is there (first row), followed by all the yet-to-be-resolved references to it from the different SIMD routines.

Unresolved references means relocations, so let's look at those:
```
$ readelf --wide -r target/debug/libre_rav1d.rlib | rg resize_filter
00000000000081ef  000002a700000002 R_X86_64_PC32          0000000000000000 dav1d_resize_filter + 81ef
00000000000081f9  000002a700000002 R_X86_64_PC32          0000000000000000 dav1d_resize_filter + 81f9
0000000000008203  000002a700000002 R_X86_64_PC32          0000000000000000 dav1d_resize_filter + 8203
000000000000820d  000002a700000002 R_X86_64_PC32          0000000000000000 dav1d_resize_filter + 820d
0000000000009562  0000023f00000002 R_X86_64_PC32          0000000000000000 dav1d_resize_filter + 9562
000000000000956c  0000023f00000002 R_X86_64_PC32          0000000000000000 dav1d_resize_filter + 956c
0000000000009576  0000023f00000002 R_X86_64_PC32          0000000000000000 dav1d_resize_filter + 9576
# ... more of the same ...
```
Once again, looks pretty good.

A `R_X86_64_PC32` relocation instructs the linker to patch the missing reference using a 32bit offset from the instruction pointer, something that can be done either at link- or load- time.
In this specific case, there is no reason to defer the resolution to load-time since we already know everything we need to know at link-time. Either way, looks fine.
Except it doesn't link. Why?!

It looks like everything is correct on `rav1d`'s end (and the fact that everything works flawlessly on all other platforms would tend to confirm that), and so deeper we go...


### Rust, position-independent code and relocation nightmares

On Linux, [ASLR](https://en.wikipedia.org/wiki/Address_space_layout_randomization) has long become standard: all major C compilers are configured to output PIC (position-independent code, for shared libraries) and PIE (position-independent code, for binaries) by default.
`rustc` is no different: it will ship position-independent executables by default:
```
$ file target/release/dav1d
target/release/dav1d: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=6ad723122b38f681731101b93d11556d5eb01adb, for GNU/Linux 4.4.0, not stripped
                                     ^^^
```

_This_ is why the link is failing: because we are linking our object files into a PIE, and for some reason that's a problem.

Now, 15 years ago, the solution would have been to disable PIE support entirely across your whole toolchain, and call it a day.
These days that's a no-no though: everything expects PIE and you need it to work, and so we need to understand what's wrong...

Let's look at that error message again:
```
R_X86_64_PC32 relocation at offset 0xa691 against symbol `dav1d_resize_filter' can not be used; recompile with -fPIC
```
This doesn't make any sense: we literally are compiling a PIE, that's the reason we have a problem to begin with.
And why would a PC-relative relocation ever be a problem for ASLR?
Not to mention that all of this will be statically compiled into the final `rerun` executable anyway, in which case the relocations will be resolved at link-time anyhow, so how could any of this matter at all?!

The thing with `R_X86_64_PC32` relocations is they are generally incompatible with position-independent code on 64bit platforms.
This makes sense: this kind of relocation can only jump into a ±2 GiB range from the current instruction, but the kernel will map the executable and the different libraries it depends on randomly across the entire 64bit virtual address space for ASLR, and so a 32bit signed offset will indeed likely not be enough.
The general wisdom at this point is to do away with direct relocations, and introduce an indirection through a global offset table, using e.g. a `R_X86_64_GOTPCREL`. Now the code only has to do a direct jump into a GOT that's sitting at a known, fixed offset and then another indirect jump to whatever offset is present in that GOT entry (which was put there either by the loader of the runtime dynamic linker).
This is slower a process, it requires more complicated assembly, but it generally works in all possible cases ("no problem that cannot be solved with an extra indirection").
Ian Wienand has [a good article on the matter](https://www.technovelty.org/c/position-independent-code-and-x86-64-libraries.html), which I recommend reading for a better view of the entire picture.

This is the first thing I've tried: patching `rav1d` so that everything went through a GOT indirection first.
That did indeed fix the linking, but now `rav1d` was segfaulting at runtime, probably because I messed up any one of the gazillon offsets _somewhere_.
The `rav1d` assembly codebase is fairly complex, and trying to patch all these references to jump through the GOT first is a non-trivial, extremely painful to debug task.

Technically, with enough work, one could make that work. But again, _why_? Why is it that any of these purely runtime, ASLR-related issues matter at all in our case?
All we're trying to do is resolve some symbols at link-time and call it a day, this doesn't make any sense.

Alright... deeper we go.


### Actual hell: runtime interposition

We finally reach the root reason of all our pains: runtime interposition, more commonly known by its infamous `LD_PRELOAD` environment variable.

Runtime interposition is a feature of dynamic linking on Linux that allows anybody to intercept and override any _public_ ELF symbol with their own, at load and/or run time.
The most famous use case is probably that of overriding the global C allocator from a shell:
```
LD_PRELOAD=mymalloc.so ./doom.out
```

This should trigger a look of sheer horror on your face: _that_ is the problem.

Because the symbols of our tables are public, the linker assumes that they could be intercepted at any point.
```
   676: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND dav1d_resize_filter
                                              ^^^^^^^
                                      `DEFAULT` means public, btw
```
Because the binary we're building is position-independent, the linker also assumes that whoever intercepts that symbol may live anywhere in the 64bit virtual address space.
Therefore, a `R_X86_64_PC32` cannot be used: there is no guarantee that 32bits will be enough.

Let's look at this error message one last time:
```
R_X86_64_PC32 relocation at offset 0xa691 against symbol `dav1d_resize_filter' can not be used; recompile with -fPIC
```
This is not telling us to recompile our code with `-fPIC`, it's simply telling us that our object files containing the SIMD routines needs to be PIC compliant, but right now they're not.
The problem is that it's assuming that these files were generated by one of the major C compilers, rather than simply handwritten. Passing `-fPIC` makes no sense: there's no compiler to pass it to. We _are_ the compiler.

So... we just make all these symbols non-interceptable, and we're done, right?


### The solution: have some privacy

For some reason, I haven't been able to find any documentation, forum post, or even managed to make an LLM tell me how on earth to change the visibility of an ELF symbol using nasm assembly.

But after a lot of trial and error, and mimicking other similar syntax I found across the codebase, I ended up with this syntax:
```
external var:$elf_type $elf_visibility
```

And guess what, it works:
```
$ readelf --wide -s target/release/libre_rav1d.rlib | rg resize_filter
  5141: 0000000000000000   512 OBJECT  GLOBAL DEFAULT 4682 dav1d_resize_filter
   676: 0000000000000000     0 OBJECT  GLOBAL HIDDEN   UND dav1d_resize_filter
   572: 0000000000000000     0 OBJECT  GLOBAL HIDDEN   UND dav1d_resize_filter
   474: 0000000000000000     0 OBJECT  GLOBAL HIDDEN   UND dav1d_resize_filter
   459: 0000000000000000     0 OBJECT  GLOBAL HIDDEN   UND dav1d_resize_filter
   544: 0000000000000000     0 OBJECT  GLOBAL HIDDEN   UND dav1d_resize_filter
   482: 0000000000000000     0 OBJECT  GLOBAL HIDDEN   UND dav1d_resize_filter
                                              ^^^^^^
```

And not only that, it links! :partying_face: 

As expected, the linker can now see that there's no way these symbols could ever be intercepted, and therefore they can just be linked in as-is.
All relocations are resolved at link-time, and the final binary just works :tm:. Lean and clean:
```
$ readelf --wide -s target/release/rerun | rg resize_filter
  4496: 0000000002f0f3f0     0 OBJECT  LOCAL  DEFAULT   35 dav1d_resize_filter$got
112105: 0000000000877968   512 OBJECT  LOCAL  HIDDEN    15 dav1d_resize_filter
```
```
$ readelf --wide -r target/release/rerun | rg resize_filter
# <nothing>
```

---

# Update

@Wumpf asks a very good question:
> so.. but how does this work in the original dav1d, I presume we don’t know?
> I figure they had the exact same asm files, no?
> which hints that they’re private there, just like they are now after your change. :thinking_face:

Here's what's happening there: the tables themselves are marked as hidden using compiler intrinsics:
https://github.com/memorysafety/rav1d/blob/c7d127e7e31bd3366ac7dc1717dda9782905c605/src/tables.h#L113-L115
```c
EXTERN const int8_t dav1d_mc_subpel_filters[6][15][8];
EXTERN const int8_t dav1d_mc_warp_filter[193][8];
EXTERN const int8_t dav1d_resize_filter[64][8];
```

where `EXTERN` is defined as:
https://github.com/memorysafety/rav1d/blob/c7d127e7e31bd3366ac7dc1717dda9782905c605/include/common/attributes.h#L116-L120
```c
#if (defined(__ELF__) || defined(__MACH__) || (defined(_WIN32) && defined(__clang__))) && __has_attribute(visibility)
#define EXTERN extern __attribute__((visibility("hidden")))
#else
#define EXTERN extern
#endif
```

Because of this, all the references that follow are themselves automatically marked as `HIDDEN`, and all our problems disappear.
This is also the reason why the tables themselves are not visible at all in `dav1d.so`:
```
readelf --wide -s /usr/lib/libdav1d.so | rg dav1d_
    39: 0000000000003284  1797 FUNC    GLOBAL DEFAULT   11 dav1d_open
    40: 000000000016a390   912 FUNC    GLOBAL DEFAULT   11 dav1d_flush
    41: 0000000000169910   610 FUNC    GLOBAL DEFAULT   11 dav1d_parse_sequence_header
    42: 0000000000003989    20 FUNC    GLOBAL DEFAULT   11 dav1d_close
    43: 0000000000169c60   113 FUNC    GLOBAL DEFAULT   11 dav1d_data_props_unref
    44: 0000000000169320   206 FUNC    GLOBAL DEFAULT   11 dav1d_data_wrap
    45: 0000000000002b81    12 FUNC    GLOBAL DEFAULT   11 dav1d_version
    46: 0000000000002d9f    96 FUNC    GLOBAL DEFAULT   11 dav1d_get_frame_delay
    47: 000000000016a060   413 FUNC    GLOBAL DEFAULT   11 dav1d_apply_grain
    48: 0000000000172f00   890 FUNC    GLOBAL DEFAULT   11 dav1d_get_picture
    49: 00000000001692a0   115 FUNC    GLOBAL DEFAULT   11 dav1d_data_create
    50: 0000000000169270    41 FUNC    GLOBAL DEFAULT   11 dav1d_get_event_flags
    51: 0000000000002020    11 FUNC    GLOBAL DEFAULT   11 dav1d_set_cpu_flags_mask
    52: 0000000000169ce0   253 FUNC    GLOBAL DEFAULT   11 dav1d_get_decode_error_data_props
    53: 0000000000002b8d    10 FUNC    GLOBAL DEFAULT   11 dav1d_version_api
    54: 0000000000169470     9 FUNC    GLOBAL DEFAULT   11 dav1d_data_unref
    55: 00000000001693f0   125 FUNC    GLOBAL DEFAULT   11 dav1d_data_wrap_user_data
    56: 0000000000172e50   164 FUNC    GLOBAL DEFAULT   11 dav1d_send_data
    57: 0000000000002b97    86 FUNC    GLOBAL DEFAULT   11 dav1d_default_settings
    58: 000000000016a720     9 FUNC    GLOBAL DEFAULT   11 dav1d_picture_unref
```

Bad news: I initially tried hiding the Rust symbol directly (as opposed to the external references in the assembly code), but there doesn't seem to exist any way to do that (the closest you can get to that is by using custom linker scripts in your build.rs, but even then that's just unmaintainable).

Good news: that confirms all of the above!